### PR TITLE
Fix: Get IP-Address

### DIFF
--- a/usr/local/sbin/autosuspend.tvheadend-functions
+++ b/usr/local/sbin/autosuspend.tvheadend-functions
@@ -28,7 +28,7 @@ if [ "${TVHEADEND_ENABLED:-yes}" == 'yes' ] ; then
         logit "Missing Tvheadend credentials (user and/or password)"
         return 1
     fi
-    TVHEADEND_IP=$(echo ${TVHEADEND_IP:-$(hostname -I)} | tr -d [:space:])
+    TVHEADEND_IP=$(echo ${TVHEADEND_IP:-$(hostname -I)} | cut -d' ' -f1 )
     TVHEADEND_HTTP_PORT=${TVHEADEND_HTTP_PORT:-9981}
     TVHEADEND_HTSP_PORT=${TVHEADEND_HTSP_PORT:-9982}
 else


### PR DESCRIPTION
Previously, in the case of 2 or more IP-Address, an invalid IP-Address was parsed. 
Now the first IP-Address is being used.