### PR TITLE
User friendly date and time resumeplan log entry

### DIFF
--- a/usr/local/sbin/autosuspend.main
+++ b/usr/local/sbin/autosuspend.main
@@ -115,7 +115,7 @@ if [ "$AUTO_SUSPEND" = "true" ] || [ "$AUTO_SUSPEND" = "yes" ] ; then
 					if [ "$NEXTWAKE" -gt "`expr \"\`date +%s\`\" + 1800`" ]; then
 						echo "0" > /sys/class/rtc/rtc0/wakealarm
 						echo "$NEXTWAKE" > /sys/class/rtc/rtc0/wakealarm
-						logit "will resume at $NEXTWAKE"
+						logit "will resume at `date --date=@"$NEXTWAKE"`"
 					else
 						logit "do not suspend because would have been awaken within next 30 minutes"
 						exit 0


### PR DESCRIPTION
Changed log entry for resumeplan to a more user friendly format. Instead of epoch time it's now logged in the default date and time format of the system.